### PR TITLE
Fix SOURCES continuation for register_MetaTypes

### DIFF
--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -370,7 +370,7 @@ SOURCES += \
     Version.cpp \
     WebSocket.cpp \
     ZmqSubNotifier.cpp \
-    register_MetaTypes.cpp
+    register_MetaTypes.cpp \
 
 HEADERS += \
     AbstractConnection.h \


### PR DESCRIPTION
## Summary
- fix `register_MetaTypes.cpp` line in `Fulcrum.pro` so that the SOURCES list continues properly

## Testing
- `qmake`

------
https://chatgpt.com/codex/tasks/task_e_6843f78465a483318de833b48a325be2