### PR TITLE
Remove constexpr from some constructors

### DIFF
--- a/src/bitcoin/block.h
+++ b/src/bitcoin/block.h
@@ -111,7 +111,7 @@ public:
 struct CBlockLocator {
     std::vector<uint256> vHave;
 
-    constexpr CBlockLocator() noexcept {}
+    CBlockLocator() noexcept {}
 
     explicit CBlockLocator(const std::vector<uint256> &vHaveIn)
         : vHave(vHaveIn) {}

--- a/src/bitcoin/script.h
+++ b/src/bitcoin/script.h
@@ -879,9 +879,9 @@ struct CScriptWitness
     std::vector<std::vector<unsigned char> > stack;
 
     // Some compilers complain without a default constructor
-    constexpr CScriptWitness() noexcept = default;
+    CScriptWitness() noexcept = default;
 
-    constexpr bool IsNull() const noexcept { return stack.empty(); }
+    bool IsNull() const noexcept { return stack.empty(); }
 
     void SetNull() { stack.clear(); stack.shrink_to_fit(); }
 

--- a/src/bitcoin/transaction.h
+++ b/src/bitcoin/transaction.h
@@ -121,7 +121,7 @@ public:
      */
     static constexpr int SEQUENCE_LOCKTIME_GRANULARITY = 9;
 
-    constexpr CTxIn() noexcept : nSequence{SEQUENCE_FINAL} {}
+    CTxIn() noexcept : nSequence{SEQUENCE_FINAL} {}
 
     explicit CTxIn(const COutPoint &prevoutIn, const CScript &scriptSigIn = {}, uint32_t nSequenceIn = SEQUENCE_FINAL)
         : prevout{prevoutIn}, scriptSig{scriptSigIn}, nSequence{nSequenceIn} {}


### PR DESCRIPTION
## Summary
- adjust CScriptWitness constructor and IsNull in script.h
- tweak default CTxIn constructor in transaction.h
- tweak default CBlockLocator constructor in block.h

## Testing
- `qmake`
- `make -j4 block.o transaction.o script.o`

------
https://chatgpt.com/codex/tasks/task_e_6844d12e3e8483318dbb99e46c686328