### PR TITLE
Add VGC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Docker Build](https://github.com/cculianu/Fulcrum/actions/workflows/publish.yml/badge.svg)](https://github.com/cculianu/Fulcrum/actions/workflows/publish.yml)
 [![Copr build status](https://copr.fedorainfracloud.org/coprs/jonny/BitcoinCash/package/fulcrum/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/jonny/BitcoinCash/package/fulcrum/)
 
-A fast & nimble SPV server for Bitcoin Cash, Bitcoin BTC, and Litecoin. 
+A fast & nimble SPV server for Bitcoin Cash, Bitcoin BTC, Litecoin, and VGC.
 
 For more information, visit [The Official Fulcrum Website™️](https://fulcrumserver.org/).
 
@@ -20,7 +20,7 @@ GPLv3. See the included `LICENSE.txt` file or [visit gnu.org and read the licens
 - *Fast:* Written in 100% modern `C++20` using multi-threaded and asynchronous programming techniques.
 - *A drop-in replacement for ElectronX/ElectrumX:* Fulcrum is 100% protocol-level compatible with the [Electrum Cash 1.5.3 protocol](https://electrum-cash-protocol.readthedocs.io/en/latest/). Existing server admins should feel right at home with this software since installation and management of it is nearly identical to ElectronX/ElectrumX server.
 - *Cross-platform:* While this codebase was mainly developed and tested on MacOS, Windows and Linux, it should theoretically work on any modern OS (such as *BSD) that has Qt5 Core and Qt5 Networking available.
-- ***NEW!*** *Triple-coin:* Supports BCH, BTC and LTC.
+- ***NEW!*** *Quadruple-coin:* Supports BCH, BTC, LTC and VGC.
 
 ### Requirements
 
@@ -30,6 +30,7 @@ GPLv3. See the included `LICENSE.txt` file or [visit gnu.org and read the licens
     - *For **BTC***: Bitcoin Core v0.17.0 or later.  No other full nodes are supported by this software for BTC.
     - *For **LTC***: Litecoin Core v0.17.0 or later.  No other full nodes are supported by this software for LTC.
       - If using Litcoin Core v0.21.2 or above, your daemon is serializing data using mweb extensions. While Fulcrum understands this serialization format, your Electrum-LTC clients may not. You can run `litecoind` with `-rpcserialversion=1` to have your daemon return transactions in pre-mweb format which is understood by most Electrum-LTC clients.
+    - *For **VGC***: Fitoshi full node.
     - The node must have txindex enabled e.g. `txindex=1`.
     - The node must not be a pruning node.
     - *Optional*: For best results, enable zmq for the "hasblock" topic using e.g. `zmqpubhashblock=tcp://0.0.0.0:8433` in your `bitcoin.conf` file (zmq is only available on: Core, BCHN, BU 1.9.1+, or Litecoin Core).

--- a/resources.qrc
+++ b/resources.qrc
@@ -10,5 +10,6 @@
         <file>resources/btc/servers_testnet4.json</file>
         <file>resources/ltc/servers.json</file>
         <file>resources/ltc/servers_testnet.json</file>
+        <file>resources/vgc/servers.json</file>
     </qresource>
 </RCC>

--- a/resources/vgc/servers.json
+++ b/resources/vgc/servers.json
@@ -1,0 +1,14 @@
+{
+    "node1.fiveg.cash": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4.2"
+    },
+    "node2.fiveg.cash": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4.2"
+    }
+}

--- a/src/BTC.cpp
+++ b/src/BTC.cpp
@@ -188,13 +188,14 @@ namespace BTC
         return nameNetMap.value(name, Net::Invalid /* default if not found */);
     }
 
-    namespace { const QString coinNameBCH{"BCH"}, coinNameBTC{"BTC"}, coinNameLTC{"LTC"}; }
+    namespace { const QString coinNameBCH{"BCH"}, coinNameBTC{"BTC"}, coinNameLTC{"LTC"}, coinNameVGC{"VGC"}; }
     QString coinToName(Coin c) {
         QString ret; // for NRVO
         switch (c) {
         case Coin::BCH: ret = coinNameBCH; break;
         case Coin::BTC: ret = coinNameBTC; break;
         case Coin::LTC: ret = coinNameLTC; break;
+        case Coin::VGC: ret = coinNameVGC; break;
         case Coin::Unknown: break;
         }
         return ret;
@@ -203,6 +204,7 @@ namespace BTC
         if (s == coinNameBCH) return Coin::BCH;
         if (s == coinNameBTC) return Coin::BTC;
         if (s == coinNameLTC) return Coin::LTC;
+        if (s == coinNameVGC) return Coin::VGC;
         return Coin::Unknown;
     }
 

--- a/src/BTC.h
+++ b/src/BTC.h
@@ -45,7 +45,7 @@
 namespace BTC
 {
     /// Used by the Storage and Controller subsystem to figure out what coin we are on (BCH vs BTC vs LTC)
-    enum class Coin { Unknown = 0, BCH, BTC, LTC };
+    enum class Coin { Unknown = 0, BCH, BTC, LTC, VGC };
 
     QString coinToName(Coin);
     Coin coinFromName(const QString &);

--- a/src/BitcoinD.cpp
+++ b/src/BitcoinD.cpp
@@ -195,7 +195,7 @@ BitcoinD *BitcoinDMgr::getBitcoinD()
 
 namespace {
     struct BitcoinDVersionParseResult {
-        bool isBchd{}, isCore{}, isBU{}, isBCHN{}, isLTC{}, isFlowee{};
+        bool isBchd{}, isCore{}, isBU{}, isBCHN{}, isLTC{}, isFlowee{}, isVGC{};
         Version version;
 
         constexpr BitcoinDVersionParseResult() noexcept = default;
@@ -228,6 +228,7 @@ namespace {
             isBCHN = subversion.startsWith("/Bitcoin Cash Node:");
             isLTC = subversion.startsWith("/LitecoinCore:");
             isFlowee = subversion.startsWith("/Flowee:");
+            isVGC = subversion.startsWith("/Fitoshi:");
             // regular bitcoind, "version" is reliable and always the same format
             version = Version::BitcoinDCompact(val);
         }
@@ -279,8 +280,8 @@ void BitcoinDMgr::refreshBitcoinDNetworkInfo()
                 }(bitcoinDInfo.subversion, networkInfo);
                 // assign to shared object now from stack object BitcoinDVersionParseResult
                 std::tie(bitcoinDInfo.isBchd, bitcoinDInfo.isCore, bitcoinDInfo.isBU, bitcoinDInfo.isLTC,
-                         bitcoinDInfo.isFlowee, bitcoinDInfo.version)
-                    = std::tie(res.isBchd, res.isCore, res.isBU, res.isLTC, res.isFlowee, res.version);
+                         bitcoinDInfo.isFlowee, bitcoinDInfo.isVGC, bitcoinDInfo.version)
+                    = std::tie(res.isBchd, res.isCore, res.isBU, res.isLTC, res.isFlowee, res.isVGC, res.version);
                 bitcoinDInfo.relayFee = networkInfo.value("relayfee", 0.0).toDouble();
                 bitcoinDInfo.warnings = networkInfo.value("warnings", "").toString();
                 // set quirk flags: requires 0 arg `estimatefee`?
@@ -308,6 +309,7 @@ void BitcoinDMgr::refreshBitcoinDNetworkInfo()
             BTC::Coin coin = BTC::Coin::BCH; // default BCH if unknown (not segwit)
             if (res.isCore) coin = BTC::Coin::BTC; // segwit
             else if (res.isLTC) coin = BTC::Coin::LTC; // segwit
+            else if (res.isVGC) coin = BTC::Coin::VGC;
             emit coinDetected(coin);
             // next, be sure to set up the ping time appropriately for bchd vs bitcoind
             resetPingTimers(int(res.isBchd ? PingTimes::BCHD : PingTimes::Normal));

--- a/src/BitcoinD.h
+++ b/src/BitcoinD.h
@@ -54,6 +54,7 @@ struct BitcoinDInfo {
     bool isLTC = false; ///< true if we are actually connected to /LitecoinCore.. node (Litecoin)
     bool isBU = false; ///< true if subversion string starts with "/BCH Unlimited:"
     bool isFlowee = false; ///< true if subversion string starts with "/Flowee"
+    bool isVGC = false; ///< true if subversion string starts with "/Fitoshi:"
     bool lacksGetZmqNotifications = false; ///< true if bchd or BU < 1.9.1.0, or if we got an RPC error the last time we queried
     bool hasDSProofRPC = false; ///< true if the RPC query to `getdsprooflist` didn't return an error.
 


### PR DESCRIPTION
## Summary
- add new coin `VGC`
- map VGC names in coin utils
- detect Fitoshi daemon and expose new flag
- ship example VGC peer list
- document support for VGC in README
- update VGC seed servers

## Testing
- `qmake -makefile CONFIG+=release DEFINES+=ENABLE_TESTS Fulcrum.pro`
- `make -j$(nproc)` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6844dcb04f9483318921ffc6fb2406da