### PR TITLE
Implement coin-specific header verification

### DIFF
--- a/src/BTC.cpp
+++ b/src/BTC.cpp
@@ -104,15 +104,21 @@ namespace BTC
     bool HeaderVerifier::operator()(const QByteArray & header, QString *err)
     {
         const long height = prevHeight+1;
-        if (header.size() != BTC::GetBlockHeaderSize()) {
+        if (header.size() < BTC::GetBlockHeaderSize()) {
             if (err) *err = QString("Header verification failed for header at height %1: wrong size").arg(height);
             return false;
         }
-        bitcoin::CBlockHeader curHdr = Deserialize<bitcoin::CBlockHeader>(header);
+        const QByteArray headerBytes = header.left(BTC::GetBlockHeaderSize());
+        bitcoin::CBlockHeader curHdr = Deserialize<bitcoin::CBlockHeader>(headerBytes);
         if (!checkInner(height, curHdr, err))
             return false;
         prevHeight = height;
-        prev = header;
+        prev = headerBytes;
+        QByteArray prevBig = prevHash;
+        std::reverse(prevBig.begin(), prevBig.end());
+        QByteArray h = BlockHashForCoin(headerBytes, prevBig, coinType);
+        prevHash = h;
+        std::reverse(prevHash.begin(), prevHash.end());
         if (err) err->clear();
         return true;
     }
@@ -120,14 +126,20 @@ namespace BTC
     {
         const long height = prevHeight+1;
         QByteArray header = Serialize(curHdr);
-        if (header.size() != BTC::GetBlockHeaderSize()) {
+        if (header.size() < BTC::GetBlockHeaderSize()) {
             if (err) *err = QString("Header verification failed for header at height %1: wrong size").arg(height);
             return false;
         }
+        header.truncate(BTC::GetBlockHeaderSize());
         if (!checkInner(height, curHdr, err))
             return false;
         prevHeight = height;
         prev = header;
+        QByteArray prevBig = prevHash;
+        std::reverse(prevBig.begin(), prevBig.end());
+        QByteArray h = BlockHashForCoin(header, prevBig, coinType);
+        prevHash = h;
+        std::reverse(prevHash.begin(), prevHash.end());
         if (err) err->clear();
         return true;
     }
@@ -138,9 +150,12 @@ namespace BTC
             if (err) *err = QString("Header verification failed for header at height %1: failed to deserialize").arg(height);
             return false;
         }
-        if (!prev.isEmpty() && Hash(prev) != QByteArray::fromRawData(reinterpret_cast<const char *>(curHdr.hashPrevBlock.begin()), int(curHdr.hashPrevBlock.width())) ) {
-            if (err) *err = QString("Header %1 'hashPrevBlock' does not match the contents of the previous block").arg(height);
-            return false;
+        if (!prev.isEmpty()) {
+            QByteArray expected = QByteArray::fromRawData(reinterpret_cast<const char *>(curHdr.hashPrevBlock.begin()), int(curHdr.hashPrevBlock.width()));
+            if (expected != prevHash) {
+                if (err) *err = QString("Header %1 'hashPrevBlock' does not match the contents of the previous block").arg(height);
+                return false;
+            }
         }
         return true;
     }

--- a/src/BTC.h
+++ b/src/BTC.h
@@ -208,12 +208,17 @@ namespace BTC
     /// If that is ever not the case, operator() returns false. Returns true otherwise.
     class HeaderVerifier {
         QByteArray prev; // 80 byte header data or empty
+        QByteArray prevHash; ///< the hash of the previous header, BlockHashForCoin() form
         long prevHeight = -1;
+        Coin coinType{Coin::Unknown};
 
         bool checkInner(long height, const bitcoin::CBlockHeader &, QString *err);
     public:
         HeaderVerifier() = default;
         HeaderVerifier(unsigned fromHeight) : prevHeight(long(fromHeight)-1) {}
+        explicit HeaderVerifier(Coin c) : coinType(c) {}
+
+        void setCoin(Coin c) { coinType = c; }
 
         /// keep calling this from a loop. Returns false if current header's hashPrevBlock  != the last header's hash.
         bool operator()(const QByteArray & header, QString *err = nullptr);
@@ -222,7 +227,14 @@ namespace BTC
         std::pair<int, QByteArray> lastHeaderProcessed() const;
 
         bool isValid() const { return prev.length() == GetBlockHeaderSize(); }
-        void reset(unsigned nextHeight = 0, QByteArray prevHeader = QByteArray()) { prevHeight = long(nextHeight)-1; prev = prevHeader; }
+        void reset(unsigned nextHeight = 0, QByteArray prevHeader = QByteArray(), QByteArray prevHashIn = QByteArray())
+        {
+            prevHeight = long(nextHeight)-1;
+            prev = std::move(prevHeader);
+            prevHash = std::move(prevHashIn);
+            if (!prevHash.isEmpty())
+                std::reverse(prevHash.begin(), prevHash.end());
+        }
     };
 
     /// Trivial hasher for sha256, rmd160, etc hashed byte arrays (for use with std::unordered_map,

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -2290,6 +2290,10 @@ void Storage::setCoin(const QString &coin) {
     if (!coin.isEmpty())
         Log() << "Coin: " << coin;
     save(SaveItem::Meta);
+    {
+        auto [verif, lock] = headerVerifier();
+        verif.setCoin(BTC::coinFromName(coin));
+    }
 }
 
 bool Storage::isRpaEnabled() const
@@ -2488,6 +2492,7 @@ void Storage::loadCheckHeadersInDB()
                 throw DatabaseFormatError(QString("%1. Possible databaase corruption. Delete the datadir and resynch.").arg(err.isEmpty() ? "Could not read all headers" : err));
 
             auto [verif, lock] = headerVerifier();
+            verif.setCoin(BTC::coinFromName(getCoin()));
             // set genesis hash
             {
                 const auto coin = BTC::coinFromName(getCoin());
@@ -3798,7 +3803,8 @@ BlockHeight Storage::undoLatestBlock(bool notifySubs)
             // all sanity check passed. Now, undo things in reverse order of what we did in addBlock above, rougly speaking
 
             // first, undo the header
-            p->headerVerifier.reset(prevHeight+1, prevHeader);
+            QByteArray newPrevHash = BTC::BlockHashForCoin(prevHeader, chkPrev, coinTmp);
+            p->headerVerifier.reset(prevHeight+1, prevHeader, newPrevHash);
             setDirty(true); // <-- no turning back. we clear this flag at the end
             deleteHeadersPastHeight(prevHeight); // commit change to db
             p->merkleCache->truncate(prevHeight+1); // this takes a length, not a height, which is always +1 the height


### PR DESCRIPTION
## Summary
- enhance `HeaderVerifier` with coin type and previous hash handling
- allow verifying headers bigger than 80 bytes
- keep coin type in `Storage::setCoin` and during DB load
- compute proper previous hash on undo and store for next verification

## Testing
- `qmake Fulcrum.pro`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68451dca2d1c8331b62fbf5522725f8a