### PR TITLE
Implement extended header API

### DIFF
--- a/src/BTC.cpp
+++ b/src/BTC.cpp
@@ -104,15 +104,21 @@ namespace BTC
     bool HeaderVerifier::operator()(const QByteArray & header, QString *err)
     {
         const long height = prevHeight+1;
-        if (header.size() != BTC::GetBlockHeaderSize()) {
+        if (header.size() < BTC::GetBlockHeaderSize()) {
             if (err) *err = QString("Header verification failed for header at height %1: wrong size").arg(height);
             return false;
         }
-        bitcoin::CBlockHeader curHdr = Deserialize<bitcoin::CBlockHeader>(header);
+        const QByteArray headerBytes = header.left(BTC::GetBlockHeaderSize());
+        bitcoin::CBlockHeader curHdr = Deserialize<bitcoin::CBlockHeader>(headerBytes);
         if (!checkInner(height, curHdr, err))
             return false;
         prevHeight = height;
-        prev = header;
+        prev = headerBytes;
+        QByteArray prevBig = prevHash;
+        std::reverse(prevBig.begin(), prevBig.end());
+        QByteArray h = BlockHashForCoin(headerBytes, prevBig, coinType);
+        prevHash = h;
+        std::reverse(prevHash.begin(), prevHash.end());
         if (err) err->clear();
         return true;
     }
@@ -120,14 +126,20 @@ namespace BTC
     {
         const long height = prevHeight+1;
         QByteArray header = Serialize(curHdr);
-        if (header.size() != BTC::GetBlockHeaderSize()) {
+        if (header.size() < BTC::GetBlockHeaderSize()) {
             if (err) *err = QString("Header verification failed for header at height %1: wrong size").arg(height);
             return false;
         }
+        header.truncate(BTC::GetBlockHeaderSize());
         if (!checkInner(height, curHdr, err))
             return false;
         prevHeight = height;
         prev = header;
+        QByteArray prevBig = prevHash;
+        std::reverse(prevBig.begin(), prevBig.end());
+        QByteArray h = BlockHashForCoin(header, prevBig, coinType);
+        prevHash = h;
+        std::reverse(prevHash.begin(), prevHash.end());
         if (err) err->clear();
         return true;
     }
@@ -138,9 +150,12 @@ namespace BTC
             if (err) *err = QString("Header verification failed for header at height %1: failed to deserialize").arg(height);
             return false;
         }
-        if (!prev.isEmpty() && Hash(prev) != QByteArray::fromRawData(reinterpret_cast<const char *>(curHdr.hashPrevBlock.begin()), int(curHdr.hashPrevBlock.width())) ) {
-            if (err) *err = QString("Header %1 'hashPrevBlock' does not match the contents of the previous block").arg(height);
-            return false;
+        if (!prev.isEmpty()) {
+            QByteArray expected = QByteArray::fromRawData(reinterpret_cast<const char *>(curHdr.hashPrevBlock.begin()), int(curHdr.hashPrevBlock.width()));
+            if (expected != prevHash) {
+                if (err) *err = QString("Header %1 'hashPrevBlock' does not match the contents of the previous block").arg(height);
+                return false;
+            }
         }
         return true;
     }

--- a/src/BTC.h
+++ b/src/BTC.h
@@ -152,6 +152,18 @@ namespace BTC
 
     /// Helper -- returns the size of a block header. Should always be 80. Update this if that changes.
     constexpr int GetBlockHeaderSize() noexcept { return 80; }
+    /// Returns any extra bytes found at the end of a block header for a coin.
+    /// BCH/BTC/LTC headers have no extra bytes, but other coins may extend the
+    /// header with additional data.  The return value is the number of extra
+    /// bytes that come after the standard 80-byte header.
+    constexpr int extraHeaderSizeForCoin(Coin coin) noexcept
+    {
+        switch (coin) {
+        case Coin::VGC: return 4; // VGC headers include 4 additional bytes
+        default: break;
+        }
+        return 0;
+    }
 
     /// Returns the sha256 double hash (not reveresed -- little endian) of the input QByteArray. The results are copied
     /// once from the hasher into the returned QByteArray.  This is faster than obtaining a uint256 from bitcoin::Hash
@@ -208,12 +220,18 @@ namespace BTC
     /// If that is ever not the case, operator() returns false. Returns true otherwise.
     class HeaderVerifier {
         QByteArray prev; // 80 byte header data or empty
+        /// previous block hash in little-endian order (matches CBlockHeader::hashPrevBlock)
+        QByteArray prevHash;
         long prevHeight = -1;
+        Coin coinType{Coin::Unknown};
 
         bool checkInner(long height, const bitcoin::CBlockHeader &, QString *err);
     public:
         HeaderVerifier() = default;
         HeaderVerifier(unsigned fromHeight) : prevHeight(long(fromHeight)-1) {}
+        explicit HeaderVerifier(Coin c) : coinType(c) {}
+
+        void setCoin(Coin c) { coinType = c; }
 
         /// keep calling this from a loop. Returns false if current header's hashPrevBlock  != the last header's hash.
         bool operator()(const QByteArray & header, QString *err = nullptr);
@@ -222,7 +240,15 @@ namespace BTC
         std::pair<int, QByteArray> lastHeaderProcessed() const;
 
         bool isValid() const { return prev.length() == GetBlockHeaderSize(); }
-        void reset(unsigned nextHeight = 0, QByteArray prevHeader = QByteArray()) { prevHeight = long(nextHeight)-1; prev = prevHeader; }
+        /// Reinitialize verifier state. prevHashIn should be the previous block hash in big-endian form.
+        void reset(unsigned nextHeight = 0, QByteArray prevHeader = QByteArray(), QByteArray prevHashIn = QByteArray())
+        {
+            prevHeight = long(nextHeight)-1;
+            prev = std::move(prevHeader);
+            prevHash = std::move(prevHashIn);
+            if (!prevHash.isEmpty())
+                std::reverse(prevHash.begin(), prevHash.end());
+        }
     };
 
     /// Trivial hasher for sha256, rmd160, etc hashed byte arrays (for use with std::unordered_map,

--- a/src/BlockProc.cpp
+++ b/src/BlockProc.cpp
@@ -34,13 +34,15 @@
 /* static */ const TxHash PreProcessedBlock::nullhash;
 
 /// fill this struct's data with all the txdata, etc from a bitcoin CBlock. Alternative to using the second c'tor.
-void PreProcessedBlock::fill(BlockHeight blockHeight, size_t blockSize, const bitcoin::CBlock &b, CoTask *rpaTask) {
+void PreProcessedBlock::fill(BlockHeight blockHeight, size_t blockSize, const bitcoin::CBlock &b,
+                             CoTask *rpaTask, QByteArray extra) {
     if (!header.IsNull() || !txInfos.empty())
         clear();
     height = blockHeight;
     sizeBytes = blockSize;
     header = b.GetBlockHeader();
-    estimatedThisSizeBytes = sizeof(*this) + size_t(BTC::GetBlockHeaderSize());
+    extraHeader = std::move(extra);
+    estimatedThisSizeBytes = sizeof(*this) + size_t(BTC::GetBlockHeaderSize()) + extraHeader.size();
     txInfos.reserve(b.vtx.size());
     std::unordered_map<TxHash, unsigned, HashHasher> txHashToIndex; // since we know the size ahead of time here, we can set max_load_factor to 1.0 and avoid over-allocating the hash table
     txHashToIndex.max_load_factor(1.0);
@@ -269,9 +271,10 @@ QString PreProcessedBlock::toDebugString() const
 
 /// convenience factory static method: given a block, return a shard_ptr instance of this struct
 /*static*/
-PreProcessedBlockPtr PreProcessedBlock::makeShared(unsigned height_, size_t size, const bitcoin::CBlock &block, CoTask *rpaTask)
+PreProcessedBlockPtr PreProcessedBlock::makeShared(unsigned height_, size_t size, const bitcoin::CBlock &block,
+                                                   CoTask *rpaTask, QByteArray extra)
 {
-    return std::make_shared<PreProcessedBlock>(height_, size, block, rpaTask);
+    return std::make_shared<PreProcessedBlock>(height_, size, block, rpaTask, std::move(extra));
 }
 
 

--- a/src/BlockProc.h
+++ b/src/BlockProc.h
@@ -48,6 +48,7 @@ struct PreProcessedBlock
     size_t estimatedThisSizeBytes = 0; ///< the estimated size of this data structure -- may be off by a bit but is useful for rough estimation of memory costs of block processing
     /// deserialized header as came in from bitcoind
     bitcoin::CBlockHeader header;
+    QByteArray extraHeader;
 
     struct TxInfo {
         TxHash hash; ///< 32 byte txid. These txid's are *reversed* from bitcoind's internal memory order. (so as to be closer to the final hex encoded format).
@@ -164,17 +165,19 @@ struct PreProcessedBlock
 
     // c'tors, etc... note this class is fully copyable and moveable
     PreProcessedBlock() = default;
-    PreProcessedBlock(BlockHeight bheight, size_t rawBlockSizeBytes, const bitcoin::CBlock &b, CoTask *rpaTask /* nullable */) {
-        fill(bheight, rawBlockSizeBytes, b, rpaTask);
+    PreProcessedBlock(BlockHeight bheight, size_t rawBlockSizeBytes, const bitcoin::CBlock &b,
+                      CoTask *rpaTask /* nullable */, QByteArray extra = {}) {
+        fill(bheight, rawBlockSizeBytes, b, rpaTask, std::move(extra));
     }
     /// reset this to empty
     inline void clear() { *this = PreProcessedBlock(); }
     /// fill this block with data from bitcoin's CBlock
-    void fill(BlockHeight blockHeight, size_t rawSizeBytes, const bitcoin::CBlock &b, CoTask *rpaTask /* nullable */);
+    void fill(BlockHeight blockHeight, size_t rawSizeBytes, const bitcoin::CBlock &b,
+              CoTask *rpaTask /* nullable */, QByteArray extra = {});
 
     /// convenience factory static method: given a block, return a shard_ptr instance of this struct
     static PreProcessedBlockPtr makeShared(unsigned height, size_t sizeBytes, const bitcoin::CBlock &block,
-                                           CoTask *rpaTask /* nullable */);
+                                           CoTask *rpaTask /* nullable */, QByteArray extra = {});
 
     /// debug string
     QString toDebugString() const;

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -496,7 +496,7 @@ struct DownloadBlocksTask : CtlTask
     int q_ct = 0;
     const int max_q; // todo: tune this, for now it is numBitcoinDClients + 1
 
-    static constexpr int HEADER_SIZE = BTC::GetBlockHeaderSize();
+    const int HEADER_SIZE = BTC::GetBlockHeaderSize() + BTC::extraHeaderSizeForCoin(ctl->coinType());
 
     std::atomic<size_t> nTx = 0, nIns = 0, nOuts = 0;
 
@@ -517,7 +517,7 @@ struct DownloadBlocksTask : CtlTask
     // given a block height, return the index into our array
     size_t height2Index(size_t h) { return size_t( ((h-from) + stride-1) / stride ); }
 protected:
-    virtual VarDLTaskResult process_block_guts(unsigned bnum, const QByteArray &rawblock, const bitcoin::CBlock &cblock);
+    virtual VarDLTaskResult process_block_guts(unsigned bnum, const QByteArray &rawblock, const bitcoin::CBlock &cblock, const QByteArray &extraHeader);
 };
 
 DownloadBlocksTask::DownloadBlocksTask(unsigned from, unsigned to, unsigned stride, unsigned nClients, int rpaHeight, Controller *ctl_)
@@ -574,19 +574,23 @@ void DownloadBlocksTask::do_get(unsigned int bnum)
             submitRequest("getblock", {var, false}, [this, bnum, hash](const RPC::Message & resp){
                 try {
                     auto rawblock = Util::ParseHexFast(resp.result().toByteArray());
-                    const auto header = rawblock.left(HEADER_SIZE); // we need a deep copy of this anyway so might as well take it now.
+                    const auto header = rawblock.left(HEADER_SIZE); // deep copy
+                    const auto stdHeader = header.left(BTC::GetBlockHeaderSize());
+                    const auto extraHeader = header.mid(BTC::GetBlockHeaderSize());
                     QByteArray chkHash;
-                    const auto prevBytes = header.mid(4, 32);
+                    const auto prevBytes = stdHeader.mid(4, 32);
                     QByteArray prevHash(prevBytes);
                     std::reverse(prevHash.begin(), prevHash.end());
                     if (bool sizeOk = header.length() == HEADER_SIZE;
-                        sizeOk && (chkHash = BTC::BlockHashForCoin(header, prevHash, ctl->isVGCCoin() ? BTC::Coin::VGC : BTC::Coin::Unknown)) == hash) {
+                        sizeOk && (chkHash = BTC::BlockHashForCoin(stdHeader, prevHash, ctl->isVGCCoin() ? BTC::Coin::VGC : BTC::Coin::Unknown)) == hash) {
                         PreProcessedBlockPtr maybe_ppb; // either this is filled
                         Controller::RpaOnlyModeDataPtr maybe_rpaOnlyMode;  // or this is.. but not both!
                         try {
-                            const auto cblock = BTC::Deserialize<bitcoin::CBlock>(rawblock, 0, allowSegWit, allowMimble, allowCashTokens, allowMimble /* throw if junk at end if Litecoin (catch deser. bugs) */);
+                            QByteArray trimmed = rawblock;
+                            trimmed.remove(BTC::GetBlockHeaderSize(), extraHeader.size());
+                            const auto cblock = BTC::Deserialize<bitcoin::CBlock>(trimmed, 0, allowSegWit, allowMimble, allowCashTokens, allowMimble /* throw if junk at end if Litecoin (catch deser. bugs) */);
                             {
-                                VarDLTaskResult var = process_block_guts(bnum, rawblock, cblock);
+                                VarDLTaskResult var = process_block_guts(bnum, rawblock, cblock, extraHeader);
                                 std::visit(
                                     Overloaded{
                                         [&](PreProcessedBlockPtr & p) { maybe_ppb = std::move(p); },
@@ -717,7 +721,7 @@ void DownloadBlocksTask::do_get(unsigned int bnum)
 // This has been refactored out of do_get() above to offer polymorphic subclasses the ability to also leverage
 // the DownloadBlocksTask to get blocks to synch various things (such as synching the RPA index if it is detected to
 // be out-of-synch due to configuration change, etc).
-VarDLTaskResult DownloadBlocksTask::process_block_guts(unsigned bnum, const QByteArray &rawblock, const bitcoin::CBlock &cblock)
+VarDLTaskResult DownloadBlocksTask::process_block_guts(unsigned bnum, const QByteArray &rawblock, const bitcoin::CBlock &cblock, const QByteArray &extraHeader)
 {
     CoTask * rpaTaskIfEnabledForThisBlock = nullptr;
     // Determine if RPA indexing is enabled for this block, and if so, ensure this->rpaTask is created and pass down a
@@ -728,7 +732,9 @@ VarDLTaskResult DownloadBlocksTask::process_block_guts(unsigned bnum, const QByt
         rpaTaskIfEnabledForThisBlock = &*rpaTask;
     }
 
-    auto ppb = PreProcessedBlock::makeShared(bnum, size_t(rawblock.size()), cblock, rpaTaskIfEnabledForThisBlock);
+    auto ppb = PreProcessedBlock::makeShared(bnum, size_t(rawblock.size()), cblock,
+                                            rpaTaskIfEnabledForThisBlock,
+                                            extraHeader);
 
     if (UNLIKELY(rpaIsEnabledForThisBlock && bnum == unsigned(rpaStartHeight))) {
         Util::AsyncOnObject(ctl, [height = rpaStartHeight]{
@@ -746,10 +752,10 @@ struct DownloadBlocksTask_SynchRpa : DownloadBlocksTask
 {
     using DownloadBlocksTask::DownloadBlocksTask;
 protected:
-    VarDLTaskResult process_block_guts(unsigned bnum, const QByteArray &rawblock, const bitcoin::CBlock &cblock) override final;
+    VarDLTaskResult process_block_guts(unsigned bnum, const QByteArray &rawblock, const bitcoin::CBlock &cblock, const QByteArray &extraHeader) override final;
 };
 
-VarDLTaskResult DownloadBlocksTask_SynchRpa::process_block_guts(unsigned bnum, const QByteArray &rawblock, const bitcoin::CBlock &cblock)
+VarDLTaskResult DownloadBlocksTask_SynchRpa::process_block_guts(unsigned bnum, const QByteArray &rawblock, const bitcoin::CBlock &cblock, const QByteArray &)
 {
     Controller::RpaOnlyModeDataPtr ret = std::make_shared<Controller::RpaOnlyModeData>();
     ret->height = bnum;

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -1368,6 +1368,13 @@ static QVariantMap mkHeaderHexResponse(unsigned height, const QByteArray & heade
     m.insert(QByteArrayLiteral("hex"), Util::ToHexFast(header));
     return m;
 }
+static QVariantMap mkHeaderHexResponseEx(unsigned height, const QByteArray & header)
+{
+    QVariantMap m;
+    m.insert(QByteArrayLiteral("height"), height);
+    m.insert(QByteArrayLiteral("hex"), Util::ToHexFast(header));
+    return m;
+}
 void Server::rpc_blockchain_headers_get_tip(Client *c, const RPC::BatchId batchId, const RPC::Message &m)
 {
     Storage::Header hdr;
@@ -1445,6 +1452,46 @@ void Server::rpc_blockchain_header_get(Client *c, const RPC::BatchId batchId, co
     } else {
         throw RPCError("Invalid height or hash specified", RPC::ErrorCodes::Code_InvalidParams);
     }
+}
+
+void Server::rpc_blockchain_header_get_ex(Client *c, const RPC::BatchId batchId, const RPC::Message &m)
+{
+    const QVariantList l(m.paramsList());
+    assert(!l.isEmpty());
+    if (const auto var = l[0]; Compat::IsMetaType(var, QMetaType::Type::QString) || Compat::IsMetaType(var, QMetaType::Type::QByteArray)) {
+        const BlockHash blockHash = parseFirstHashParamCommon(m, "Invalid blockhash");
+        generic_async_to_bitcoind(c, batchId, m.id, "getblockheader", {var, true},
+                                  [blockHash, this, c, batchId, msgId = m.id](const RPC::Message &resp){
+            const auto map = resp.result().toMap();
+            bool ok;
+            if (!map.contains("confirmations") || map.value("confirmations", -1).toInt(&ok) < 0 || !ok)
+                throw RPCError("Block not in active chain");
+            const BlockHeight height = map.value("height", "").toUInt(&ok);
+            if (!ok)
+                throw RPCError("Unable to parse height response from bitcoind", RPC::ErrorCodes::Code_InternalError);
+            impl_blockchain_header_get_ex(c, batchId, msgId, height);
+            return DontAutoSendReply;
+        });
+    } else if (var.canConvert<int>()) {
+        bool ok;
+        const int height = var.toInt(&ok);
+        if (!ok || height < 0)
+            throw RPCError("Invalid height");
+        impl_blockchain_header_get_ex(c, batchId, m.id, height);
+    } else {
+        throw RPCError("Invalid height or hash specified", RPC::ErrorCodes::Code_InvalidParams);
+    }
+}
+
+void Server::impl_blockchain_header_get_ex(Client *c, const RPC::BatchId batchId, const RPC::Message::Id &msgId, const BlockHeight height)
+{
+    generic_do_async(c, batchId, msgId, [height, this]{
+        QString err;
+        const auto optHdr = storage->headerForHeight(height, &err);
+        if (!optHdr)
+            throw RPCError(err);
+        return mkHeaderHexResponseEx(height, *optHdr);
+    });
 }
 void Server::impl_blockchain_header_get(Client *c, const RPC::BatchId batchId, const RPC::Message::Id &msgId, const BlockHeight height)
 {
@@ -2452,6 +2499,7 @@ HEY_COMPILER_PUT_STATIC_HERE(Server::StaticData::registry){
     { {"blockchain.headers.subscribe",      true,               false,    PR{0,0},                    },          MP(rpc_blockchain_headers_subscribe) },
     { {"blockchain.headers.unsubscribe",    true,               false,    PR{0,0},                    },          MP(rpc_blockchain_headers_unsubscribe) },
     { {"blockchain.header.get",             true,               false,    PR{1,1},                    },          MP(rpc_blockchain_header_get) },
+    { {"blockchain.header.get_ex",          true,               false,    PR{1,1},                    },          MP(rpc_blockchain_header_get_ex) },
     { {"blockchain.relayfee",               true,               false,    PR{0,0},                    },          MP(rpc_blockchain_relayfee) },
 
     { {"blockchain.scripthash.get_balance", true,               false,    PR{1,2},                    },          MP(rpc_blockchain_scripthash_get_balance) },

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -397,6 +397,7 @@ private:
     void rpc_blockchain_headers_subscribe(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     void rpc_blockchain_headers_unsubscribe(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     void rpc_blockchain_header_get(Client *, RPC::BatchId, const RPC::Message &); // protocol v1.5.2
+    void rpc_blockchain_header_get_ex(Client *, RPC::BatchId, const RPC::Message &); // extended header
     void rpc_blockchain_relayfee(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     // scripthash
     void rpc_blockchain_scripthash_get_balance(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
@@ -445,6 +446,7 @@ private:
                                 const std::optional<QString> & aliasUsedForNotifications = {});
     void impl_generic_unsubscribe(SubsMgr *, Client *, RPC::BatchId, const RPC::Message &, const HashX &key);
     void impl_blockchain_header_get(Client *, RPC::BatchId, const RPC::Message::Id &, BlockHeight);
+    void impl_blockchain_header_get_ex(Client *, RPC::BatchId, const RPC::Message::Id &, BlockHeight);
     /// Commonly used by above methods.  Takes the first address argument in the m.paramsList() and converts it to
     /// a scripthash, returning the raw bytes.  Will throw RPCError on invalid argument.
     /// It is assumed the caller already ensured m.paramsList() has at least 1 item in it (which the RPC machinery

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1069,11 +1069,12 @@ struct Storage::Pvt
 
     Pvt(const Pvt &) = delete;
 
-    constexpr int blockHeaderSize() { return BTC::GetBlockHeaderSize(); }
+    constexpr int blockHeaderSize() { return BTC::GetBlockHeaderSize() + BTC::extraHeaderSizeForCoin(coin); }
 
     /* NOTE: If taking multiple locks, all locks should be taken in the order they are declared, to avoid deadlocks. */
 
     Meta meta;
+    BTC::Coin coin{BTC::Coin::Unknown};
     RWLock metaLock;
 
     std::atomic<std::underlying_type_t<SaveItem>> pendingSaves{0};
@@ -1979,13 +1980,16 @@ void Storage::startup()
             }
             p->meta = m_db;
             Debug () << "Read meta from db ok";
-            if (!p->meta.coin.isEmpty())
+            if (!p->meta.coin.isEmpty()) {
                 Log() << "Coin: " << p->meta.coin;
+                p->coin = BTC::coinFromName(p->meta.coin);
+            }
             if (!p->meta.chain.isEmpty())
                 Log() << "Chain: " << p->meta.chain;
         } else {
             // ok, did not exist .. write a new one to db
             saveMeta_impl();
+            p->coin = BTC::coinFromName(p->meta.coin);
         }
         if (isDirty()) {
             throw DatabaseError("It appears that " APPNAME " was forcefully killed in the middle of committing a block to the db. "
@@ -2290,6 +2294,17 @@ void Storage::setCoin(const QString &coin) {
     if (!coin.isEmpty())
         Log() << "Coin: " << coin;
     save(SaveItem::Meta);
+    {
+        auto [verif, lock] = headerVerifier();
+        verif.setCoin(BTC::coinFromName(coin));
+    }
+    p->coin = BTC::coinFromName(coin);
+    if (p->headersFile) {
+        QString err;
+        p->headersFile.reset();
+        p->headersFile = std::make_unique<RecordFile>(options->datadir + QDir::separator() + "headers",
+                                                     size_t(p->blockHeaderSize()), 0x00f026a1);
+    }
 }
 
 bool Storage::isRpaEnabled() const
@@ -2468,7 +2483,9 @@ auto Storage::headersFromHeight(BlockHeight height, unsigned count, QString *err
 void Storage::loadCheckHeadersInDB()
 {
     assert(p->blockHeaderSize() > 0);
-    p->headersFile = std::make_unique<RecordFile>(options->datadir + QDir::separator() + "headers", size_t(p->blockHeaderSize()), 0x00f026a1); // may throw
+    p->coin = BTC::coinFromName(getCoin());
+    p->headersFile = std::make_unique<RecordFile>(options->datadir + QDir::separator() + "headers",
+                                                 size_t(p->blockHeaderSize()), 0x00f026a1); // may throw
 
     Log() << "Verifying headers ...";
     uint32_t num = unsigned(p->headersFile->numRecords());
@@ -2488,6 +2505,7 @@ void Storage::loadCheckHeadersInDB()
                 throw DatabaseFormatError(QString("%1. Possible databaase corruption. Delete the datadir and resynch.").arg(err.isEmpty() ? "Could not read all headers" : err));
 
             auto [verif, lock] = headerVerifier();
+            verif.setCoin(BTC::coinFromName(getCoin()));
             // set genesis hash
             {
                 const auto coin = BTC::coinFromName(getCoin());
@@ -3644,6 +3662,7 @@ void Storage::addBlock(PreProcessedBlockPtr ppb, bool saveUndo, unsigned nReserv
                 if constexpr (debugPrt) DebugM("Deleted undo for block ", expireUndoHeight, ", earliest now ", p->earliestUndoHeight.load());
             }
 
+            rawHeader += ppb->extraHeader;
             appendHeader(rawHeader, ppb->height);
 
             if (UNLIKELY(ppb->height == 0)) {
@@ -3655,7 +3674,7 @@ void Storage::addBlock(PreProcessedBlockPtr ppb, bool saveUndo, unsigned nReserv
                     prev = QByteArray(prev);
                     std::reverse(prev.begin(), prev.end());
                 }
-                p->genesisHash = BTC::BlockHashForCoin(rawHeader, prev, coin); // this variable is guarded by p->headerVerifierLock
+                p->genesisHash = BTC::BlockHashForCoin(rawHeader.left(BTC::GetBlockHeaderSize()), prev, coin); // guarded by headerVerifierLock
             }
 
             if (size_t limit; p->db.utxoCache && (limit = options->utxoCache) && p->db.utxoCache->memUsage() > limit)
@@ -3798,7 +3817,8 @@ BlockHeight Storage::undoLatestBlock(bool notifySubs)
             // all sanity check passed. Now, undo things in reverse order of what we did in addBlock above, rougly speaking
 
             // first, undo the header
-            p->headerVerifier.reset(prevHeight+1, prevHeader);
+            QByteArray newPrevHash = BTC::BlockHashForCoin(prevHeader, chkPrev, coinTmp);
+            p->headerVerifier.reset(prevHeight+1, prevHeader, newPrevHash);
             setDirty(true); // <-- no turning back. we clear this flag at the end
             deleteHeadersPastHeight(prevHeight); // commit change to db
             p->merkleCache->truncate(prevHeight+1); // this takes a length, not a height, which is always +1 the height


### PR DESCRIPTION
## Summary
- add `extraHeaderSizeForCoin` helper
- support storing extended header bytes in PreProcessedBlock
- handle extra header when downloading blocks
- adjust storage for coin-specific header size
- expose `blockchain.header.get_ex` RPC method for full headers

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68451dca2d1c8331b62fbf5522725f8a