### PR TITLE
Add getter for coin type

### DIFF
--- a/src/Controller.h
+++ b/src/Controller.h
@@ -87,6 +87,9 @@ public:
         return type == BTC::Coin::BCH || type == BTC::Coin::Unknown;
     }
 
+    /// Thread-safe, lock-free, returns the current coin type
+    BTC::Coin coinType() const { return coinType.load(std::memory_order_relaxed); }
+
     /// Type used internally by the putRpaIndex signal
     struct RpaOnlyModeData {
         BlockHeight height{};


### PR DESCRIPTION
## Summary
- expose a getter on `Controller` that returns the current `BTC::Coin`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845b48377688331ae9cb21c112576ee