### PR TITLE
Add getter usage clarification

### DIFF
--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -496,7 +496,7 @@ struct DownloadBlocksTask : CtlTask
     int q_ct = 0;
     const int max_q; // todo: tune this, for now it is numBitcoinDClients + 1
 
-    const int HEADER_SIZE = BTC::GetBlockHeaderSize() + BTC::extraHeaderSizeForCoin(ctl->coinType());
+    const int HEADER_SIZE = BTC::GetBlockHeaderSize() + BTC::extraHeaderSizeForCoin(ctl->getCoinType());
 
     std::atomic<size_t> nTx = 0, nIns = 0, nOuts = 0;
 

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -87,6 +87,9 @@ public:
         return type == BTC::Coin::BCH || type == BTC::Coin::Unknown;
     }
 
+    /// Thread-safe, lock-free, returns the current coin type
+    BTC::Coin getCoinType() const { return coinType.load(std::memory_order_relaxed); }
+
     /// Type used internally by the putRpaIndex signal
     struct RpaOnlyModeData {
         BlockHeight height{};
@@ -208,8 +211,10 @@ private:
     /// notifies subscribed clients (if any).
     std::atomic_bool masterNotifySubsFlag = false;
 
-    /// Comes from DB. If DB had no entry (newly initialized DB), then we update this variable whe we first connect
-    /// to the BitcoinD.  We look for "/Satoshi..." in the useragen to set BTC, otherwise everything else is BCH.
+    /// Comes from DB. If DB had no entry (newly initialized DB), then we update this
+    /// variable when we first connect to BitcoinD. We look for "/Satoshi..." in the
+    /// user agent to set BTC; otherwise everything else is BCH. Use getCoinType() to
+    /// read the current value.
     std::atomic<BTC::Coin> coinType = BTC::Coin::Unknown;
 
     /// takes locks, prints to Log() every 30 seconds if there were changes


### PR DESCRIPTION
## Summary
- document using `getCoinType()` to read the controller's coin

## Testing
- `qmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6845b48377688331ae9cb21c112576ee