### PR TITLE
Fix header size for alternate coin types

### DIFF
--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -496,7 +496,6 @@ struct DownloadBlocksTask : CtlTask
     int q_ct = 0;
     const int max_q; // todo: tune this, for now it is numBitcoinDClients + 1
 
-    const int HEADER_SIZE = BTC::GetBlockHeaderSize() + BTC::extraHeaderSizeForCoin(ctl->coinType());
 
     std::atomic<size_t> nTx = 0, nIns = 0, nOuts = 0;
 
@@ -574,20 +573,23 @@ void DownloadBlocksTask::do_get(unsigned int bnum)
             submitRequest("getblock", {var, false}, [this, bnum, hash](const RPC::Message & resp){
                 try {
                     auto rawblock = Util::ParseHexFast(resp.result().toByteArray());
-                    const auto header = rawblock.left(HEADER_SIZE); // deep copy
+                    const int extraHeaderSize = BTC::extraHeaderSizeForCoin(ctl->getCoinType());
+                    const int headerSize = BTC::GetBlockHeaderSize() + (ctl->isVGCCoin() ? 0 : extraHeaderSize);
+                    const auto header = rawblock.left(headerSize); // deep copy
                     const auto stdHeader = header.left(BTC::GetBlockHeaderSize());
-                    const auto extraHeader = header.mid(BTC::GetBlockHeaderSize());
+                    const auto extraHeader = ctl->isVGCCoin() ? QByteArray{} : header.mid(BTC::GetBlockHeaderSize());
                     QByteArray chkHash;
                     const auto prevBytes = stdHeader.mid(4, 32);
                     QByteArray prevHash(prevBytes);
                     std::reverse(prevHash.begin(), prevHash.end());
-                    if (bool sizeOk = header.length() == HEADER_SIZE;
+                    if (bool sizeOk = header.length() == headerSize;
                         sizeOk && (chkHash = BTC::BlockHashForCoin(stdHeader, prevHash, ctl->isVGCCoin() ? BTC::Coin::VGC : BTC::Coin::Unknown)) == hash) {
                         PreProcessedBlockPtr maybe_ppb; // either this is filled
                         Controller::RpaOnlyModeDataPtr maybe_rpaOnlyMode;  // or this is.. but not both!
                         try {
                             QByteArray trimmed = rawblock;
-                            trimmed.remove(BTC::GetBlockHeaderSize(), extraHeader.size());
+                            const int extraHeaderSize = BTC::extraHeaderSizeForCoin(ctl->getCoinType());
+                            trimmed.remove(BTC::GetBlockHeaderSize(), extraHeaderSize);
                             const auto cblock = BTC::Deserialize<bitcoin::CBlock>(trimmed, 0, allowSegWit, allowMimble, allowCashTokens, allowMimble /* throw if junk at end if Litecoin (catch deser. bugs) */);
                             {
                                 VarDLTaskResult var = process_block_guts(bnum, rawblock, cblock, extraHeader);

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -87,6 +87,9 @@ public:
         return type == BTC::Coin::BCH || type == BTC::Coin::Unknown;
     }
 
+    /// Thread-safe, lock-free, returns the current coin type
+    BTC::Coin getCoinType() const { return coinType.load(std::memory_order_relaxed); }
+
     /// Type used internally by the putRpaIndex signal
     struct RpaOnlyModeData {
         BlockHeight height{};
@@ -208,8 +211,10 @@ private:
     /// notifies subscribed clients (if any).
     std::atomic_bool masterNotifySubsFlag = false;
 
-    /// Comes from DB. If DB had no entry (newly initialized DB), then we update this variable whe we first connect
-    /// to the BitcoinD.  We look for "/Satoshi..." in the useragen to set BTC, otherwise everything else is BCH.
+    /// Comes from DB. If DB had no entry (newly initialized DB), then we update this
+    /// variable when we first connect to BitcoinD. We look for "/Satoshi..." in the
+    /// user agent to set BTC; otherwise everything else is BCH. Use getCoinType() to
+    /// read the current value.
     std::atomic<BTC::Coin> coinType = BTC::Coin::Unknown;
 
     /// takes locks, prints to Log() every 30 seconds if there were changes

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1069,7 +1069,10 @@ struct Storage::Pvt
 
     Pvt(const Pvt &) = delete;
 
-    constexpr int blockHeaderSize() { return BTC::GetBlockHeaderSize() + BTC::extraHeaderSizeForCoin(coin); }
+    constexpr int blockHeaderSize() {
+        const int extra = BTC::extraHeaderSizeForCoin(coin);
+        return BTC::GetBlockHeaderSize() + (coin == BTC::Coin::VGC ? 0 : extra);
+    }
 
     /* NOTE: If taking multiple locks, all locks should be taken in the order they are declared, to avoid deadlocks. */
 


### PR DESCRIPTION
## Summary
- remove static HEADER_SIZE constant in `DownloadBlocksTask`
- compute block header size dynamically using `getCoinType()` when downloading blocks
- truncate VGC headers to 80 bytes when indexing

## Testing
- `qmake`
- `make -j$(nproc)`


------
https://chatgpt.com/codex/tasks/task_e_6845b48377688331ae9cb21c112576ee