### PR TITLE
Fix VGC header storage

### DIFF
--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -496,7 +496,6 @@ struct DownloadBlocksTask : CtlTask
     int q_ct = 0;
     const int max_q; // todo: tune this, for now it is numBitcoinDClients + 1
 
-    const int HEADER_SIZE = BTC::GetBlockHeaderSize() + BTC::extraHeaderSizeForCoin(ctl->coinType());
 
     std::atomic<size_t> nTx = 0, nIns = 0, nOuts = 0;
 
@@ -574,20 +573,23 @@ void DownloadBlocksTask::do_get(unsigned int bnum)
             submitRequest("getblock", {var, false}, [this, bnum, hash](const RPC::Message & resp){
                 try {
                     auto rawblock = Util::ParseHexFast(resp.result().toByteArray());
-                    const auto header = rawblock.left(HEADER_SIZE); // deep copy
+                    const int extraHeaderSize = BTC::extraHeaderSizeForCoin(ctl->getCoinType());
+                    const int headerSize = BTC::GetBlockHeaderSize() + (ctl->isVGCCoin() ? 0 : extraHeaderSize);
+                    const auto header = rawblock.left(headerSize); // deep copy
                     const auto stdHeader = header.left(BTC::GetBlockHeaderSize());
-                    const auto extraHeader = header.mid(BTC::GetBlockHeaderSize());
+                    const auto extraHeader = ctl->isVGCCoin() ? QByteArray{} : header.mid(BTC::GetBlockHeaderSize());
                     QByteArray chkHash;
                     const auto prevBytes = stdHeader.mid(4, 32);
                     QByteArray prevHash(prevBytes);
                     std::reverse(prevHash.begin(), prevHash.end());
-                    if (bool sizeOk = header.length() == HEADER_SIZE;
+                    if (bool sizeOk = header.length() == headerSize;
                         sizeOk && (chkHash = BTC::BlockHashForCoin(stdHeader, prevHash, ctl->isVGCCoin() ? BTC::Coin::VGC : BTC::Coin::Unknown)) == hash) {
                         PreProcessedBlockPtr maybe_ppb; // either this is filled
                         Controller::RpaOnlyModeDataPtr maybe_rpaOnlyMode;  // or this is.. but not both!
                         try {
                             QByteArray trimmed = rawblock;
-                            trimmed.remove(BTC::GetBlockHeaderSize(), extraHeader.size());
+                            const int extraHeaderSize = BTC::extraHeaderSizeForCoin(ctl->getCoinType());
+                            trimmed.remove(BTC::GetBlockHeaderSize(), extraHeaderSize);
                             const auto cblock = BTC::Deserialize<bitcoin::CBlock>(trimmed, 0, allowSegWit, allowMimble, allowCashTokens, allowMimble /* throw if junk at end if Litecoin (catch deser. bugs) */);
                             {
                                 VarDLTaskResult var = process_block_guts(bnum, rawblock, cblock, extraHeader);

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -87,6 +87,10 @@ public:
         return type == BTC::Coin::BCH || type == BTC::Coin::Unknown;
     }
 
+    /// Thread-safe, lock-free accessor for the current coin type.
+    /// Call this instead of reading the coinType member directly.
+    BTC::Coin getCoinType() const { return coinType.load(std::memory_order_relaxed); }
+
     /// Type used internally by the putRpaIndex signal
     struct RpaOnlyModeData {
         BlockHeight height{};
@@ -208,8 +212,10 @@ private:
     /// notifies subscribed clients (if any).
     std::atomic_bool masterNotifySubsFlag = false;
 
-    /// Comes from DB. If DB had no entry (newly initialized DB), then we update this variable whe we first connect
-    /// to the BitcoinD.  We look for "/Satoshi..." in the useragen to set BTC, otherwise everything else is BCH.
+    /// Comes from DB. If DB had no entry (newly initialized DB), then we update this
+    /// variable when we first connect to BitcoinD. We look for "/Satoshi..." in the
+    /// user agent to set BTC; otherwise everything else is BCH. Use getCoinType() to
+    /// read the current value.
     std::atomic<BTC::Coin> coinType = BTC::Coin::Unknown;
 
     /// takes locks, prints to Log() every 30 seconds if there were changes

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1069,7 +1069,10 @@ struct Storage::Pvt
 
     Pvt(const Pvt &) = delete;
 
-    constexpr int blockHeaderSize() { return BTC::GetBlockHeaderSize() + BTC::extraHeaderSizeForCoin(coin); }
+    constexpr int blockHeaderSize() {
+        const int extra = BTC::extraHeaderSizeForCoin(coin);
+        return BTC::GetBlockHeaderSize() + (coin == BTC::Coin::VGC ? 0 : extra);
+    }
 
     /* NOTE: If taking multiple locks, all locks should be taken in the order they are declared, to avoid deadlocks. */
 
@@ -3664,12 +3667,13 @@ void Storage::addBlock(PreProcessedBlockPtr ppb, bool saveUndo, unsigned nReserv
                 if constexpr (debugPrt) DebugM("Deleted undo for block ", expireUndoHeight, ", earliest now ", p->earliestUndoHeight.load());
             }
 
-            rawHeader += ppb->extraHeader;
+            const auto coin = BTC::coinFromName(getCoin());
+            if (coin != BTC::Coin::VGC)
+                rawHeader += ppb->extraHeader;
             appendHeader(rawHeader, ppb->height);
 
             if (UNLIKELY(ppb->height == 0)) {
                 // update genesis hash now if block 0 -- this info is used by rpc method server.features
-                const auto coin = BTC::coinFromName(getCoin());
                 QByteArray prev;
                 if (coin == BTC::Coin::VGC) {
                     prev = QByteArray::fromRawData(rawHeader.constData()+4, 32);


### PR DESCRIPTION
## Summary
- store only standard 80-byte block headers for VGC
- add `getCoinType()` accessor and document usage
- compute header size dynamically based on coin type

## Testing
- `qmake` *(fails: command not found)*
- `make -j$(nproc)` *(fails: No targets specified and no makefile found)*


------
https://chatgpt.com/codex/tasks/task_e_6845b48377688331ae9cb21c112576ee