### PR TITLE
Fix detection and handling of VGC block header extension

### DIFF
--- a/src/BTC.h
+++ b/src/BTC.h
@@ -159,7 +159,7 @@ namespace BTC
     constexpr int extraHeaderSizeForCoin(Coin coin) noexcept
     {
         switch (coin) {
-        case Coin::VGC: return 4; // VGC headers include 4 additional bytes
+        case Coin::VGC: return 4; // VGC headers may include a four-byte extension
         default: break;
         }
         return 0;

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -573,11 +573,18 @@ void DownloadBlocksTask::do_get(unsigned int bnum)
             submitRequest("getblock", {var, false}, [this, bnum, hash](const RPC::Message & resp){
                 try {
                     auto rawblock = Util::ParseHexFast(resp.result().toByteArray());
-                    const int extraHeaderSize = BTC::extraHeaderSizeForCoin(ctl->getCoinType());
-                    const int headerSize = BTC::GetBlockHeaderSize() + (ctl->isVGCCoin() ? 0 : extraHeaderSize);
+                    const int baseHdr = BTC::GetBlockHeaderSize();        // 80
+                    const int extSz   = BTC::extraHeaderSizeForCoin(ctl->getCoinType());
+                    bool hasExtra = ctl->isVGCCoin() &&
+                                    rawblock.size() >= baseHdr + extSz;
+
+                    const int headerSize = baseHdr + (ctl->isVGCCoin() && hasExtra ? extSz
+                                                               : (!ctl->isVGCCoin() ? extSz : 0));
                     const auto header = rawblock.left(headerSize); // deep copy
-                    const auto stdHeader = header.left(BTC::GetBlockHeaderSize());
-                    const auto extraHeader = ctl->isVGCCoin() ? QByteArray{} : header.mid(BTC::GetBlockHeaderSize());
+                    const auto stdHeader = header.left(baseHdr);
+                    QByteArray extraHeader = (hasExtra || (!ctl->isVGCCoin() && extSz))
+                                            ? header.mid(baseHdr, extSz)
+                                            : QByteArray{};
                     QByteArray chkHash;
                     const auto prevBytes = stdHeader.mid(4, 32);
                     QByteArray prevHash(prevBytes);
@@ -588,8 +595,8 @@ void DownloadBlocksTask::do_get(unsigned int bnum)
                         Controller::RpaOnlyModeDataPtr maybe_rpaOnlyMode;  // or this is.. but not both!
                         try {
                             QByteArray trimmed = rawblock;
-                            const int extraHeaderSize = BTC::extraHeaderSizeForCoin(ctl->getCoinType());
-                            trimmed.remove(BTC::GetBlockHeaderSize(), extraHeaderSize);
+                            if (hasExtra || (!ctl->isVGCCoin() && extSz))
+                                trimmed.remove(baseHdr, extSz);
                             const auto cblock = BTC::Deserialize<bitcoin::CBlock>(trimmed, 0, allowSegWit, allowMimble, allowCashTokens, allowMimble /* throw if junk at end if Litecoin (catch deser. bugs) */);
                             {
                                 VarDLTaskResult var = process_block_guts(bnum, rawblock, cblock, extraHeader);


### PR DESCRIPTION
## Summary
- detect optional VGC extension bytes when parsing blocks
- trim and pass the extra header when present
- clarify VGC header comment

## Testing
- `qmake > /tmp/qmake.log`
- `make -j$(nproc) > /tmp/make.log`

------
https://chatgpt.com/codex/tasks/task_e_68465c25fcbc83319d6e1bfc87390e5d