### PR TITLE
Clarify VGC header extension handling

### DIFF
--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -467,7 +467,8 @@ contains(DEFINES, ENABLE_TESTS) {
     HEADERS += \
         src/tests/Tests.h
     SOURCES += \
-        src/tests/ByteView_tests.cpp
+        src/tests/ByteView_tests.cpp \
+        src/tests/VGCExtension_tests.cpp
 }
 
 # Bitcoin related sources & headers

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -575,16 +575,22 @@ void DownloadBlocksTask::do_get(unsigned int bnum)
                     auto rawblock = Util::ParseHexFast(resp.result().toByteArray());
                     const int baseHdr = BTC::GetBlockHeaderSize();        // 80
                     const int extSz   = BTC::extraHeaderSizeForCoin(ctl->getCoinType());
-                    bool hasExtra = ctl->isVGCCoin() &&
-                                    rawblock.size() >= baseHdr + extSz;
+                    static const QByteArray kVgcExt{"VGC!", 4};
+                    bool hasExtra = false;
+                    if (ctl->isVGCCoin() && rawblock.size() >= baseHdr + extSz) {
+                        hasExtra = rawblock.mid(baseHdr, extSz) == kVgcExt;
+                    }
 
-                    const int headerSize = baseHdr + (ctl->isVGCCoin() && hasExtra ? extSz
-                                                               : (!ctl->isVGCCoin() ? extSz : 0));
+                    const int headerSize = baseHdr +
+                                            (ctl->isVGCCoin() ? (hasExtra ? extSz : 0)
+                                                             : extSz);
                     const auto header = rawblock.left(headerSize); // deep copy
                     const auto stdHeader = header.left(baseHdr);
-                    QByteArray extraHeader = (hasExtra || (!ctl->isVGCCoin() && extSz))
-                                            ? header.mid(baseHdr, extSz)
-                                            : QByteArray{};
+                    QByteArray extraHeader;
+                    if (!ctl->isVGCCoin())
+                        extraHeader = header.mid(baseHdr, extSz);
+                    else if (hasExtra)
+                        extraHeader = header.mid(baseHdr, extSz);
                     QByteArray chkHash;
                     const auto prevBytes = stdHeader.mid(4, 32);
                     QByteArray prevHash(prevBytes);
@@ -595,7 +601,7 @@ void DownloadBlocksTask::do_get(unsigned int bnum)
                         Controller::RpaOnlyModeDataPtr maybe_rpaOnlyMode;  // or this is.. but not both!
                         try {
                             QByteArray trimmed = rawblock;
-                            if (hasExtra || (!ctl->isVGCCoin() && extSz))
+                            if (!ctl->isVGCCoin() || hasExtra)
                                 trimmed.remove(baseHdr, extSz);
                             const auto cblock = BTC::Deserialize<bitcoin::CBlock>(trimmed, 0, allowSegWit, allowMimble, allowCashTokens, allowMimble /* throw if junk at end if Litecoin (catch deser. bugs) */);
                             {

--- a/src/tests/VGCExtension_tests.cpp
+++ b/src/tests/VGCExtension_tests.cpp
@@ -1,0 +1,26 @@
+#include "Tests.h"
+#include "BTC.h"
+#include "bitcoin/block.h"
+#include <QFile>
+
+TEST_SUITE(vgc_extension)
+{
+    TEST_CASE(no_extension_block)
+    {
+        const QString path = ":testdata/bch_block_833705.bin";
+        QFile f(path);
+        TEST_CHECK_MESSAGE(f.open(QFile::ReadOnly), "Unable to open resource");
+        const QByteArray blockData = f.readAll();
+        const int baseHdr = BTC::GetBlockHeaderSize();
+        const int extSz   = BTC::extraHeaderSizeForCoin(BTC::Coin::VGC);
+        static const QByteArray kVgcExt{"VGC!",4};
+        bool hasExtra = blockData.size() >= baseHdr + extSz &&
+                         blockData.mid(baseHdr, extSz) == kVgcExt;
+        TEST_CHECK(!hasExtra);
+        auto trimmed = blockData;
+        if (hasExtra) trimmed.remove(baseHdr, extSz);
+        auto blk = BTC::Deserialize<bitcoin::CBlock>(trimmed, 0, false, false, true, false);
+        TEST_CHECK(!blk.vtx.empty());
+    };
+}
+TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- validate VGC extra header bytes when downloading blocks
- adjust header/trim logic for when no extension is present
- add regression test for blocks lacking the extension

## Testing
- `qmake CONFIG+=release DEFINES+=ENABLE_TESTS Fulcrum.pro`
- `make -j8`
- `./Fulcrum --test all`

------
https://chatgpt.com/codex/tasks/task_e_68466201f5608331a67d2efacd6b70ae