### PR TITLE
Check bounds when seeking

### DIFF
--- a/src/bitcoin/streams.h
+++ b/src/bitcoin/streams.h
@@ -222,7 +222,12 @@ public:
     size_type GetPos() const { return m_pos; }
 
     void seek(size_type new_pos) {
-        if (new_pos < 0) throw std::ios_base::failure("Cannot seek to a negative offset");
+        if (new_pos < 0) {
+            throw std::ios_base::failure("Cannot seek to a negative offset");
+        }
+        if (new_pos > m_data.size()) {
+            throw std::ios_base::failure("VectorReader::seek(): end of data");
+        }
         m_pos = new_pos;
     }
 };


### PR DESCRIPTION
## Summary
- prevent GenericVectorReader from seeking past end of data

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468616f3d48331809e0b97522e8137