### PR TITLE
Support variable VGC header extension

### DIFF
--- a/src/BTC.h
+++ b/src/BTC.h
@@ -24,6 +24,7 @@
 #include "bitcoin/hash.h"
 #include "bitcoin/script.h"
 #include "bitcoin/streams.h"
+#include "bitcoin/serialize.h"
 #include "bitcoin/transaction.h"
 #include "bitcoin/version.h"
 
@@ -37,6 +38,7 @@
 #include <cstddef> // for std::byte, etc
 #include <cstring> // for memcpy
 #include <ios>
+#include <optional>
 #include <iterator>
 #include <type_traits>
 #include <utility> // for pair, etc
@@ -159,10 +161,31 @@ namespace BTC
     constexpr int extraHeaderSizeForCoin(Coin coin) noexcept
     {
         switch (coin) {
-        case Coin::VGC: return 4; // VGC headers may include a four-byte extension
-        default: break;
+        case Coin::VGC:
+            // VGC blocks may or may not have an extra 4-byte "VGC!" extension.
+            // Since the header size is variable, return 0 here and allow the
+            // deserialization code to trim the extension if present.
+            return 0;
+        default:
+            break;
         }
         return 0;
+    }
+
+    /// Parse a CompactSize integer at position `pos` in `ba`, returning the
+    /// value and number of bytes consumed. Returns {false,0} on failure.
+    inline std::optional<std::pair<uint64_t, int>>
+    ReadCompactSizeAt(const QByteArray &ba, int pos)
+    {
+        try {
+            bitcoin::GenericVectorReader<QByteArray> vr(bitcoin::SER_NETWORK,
+                                                        bitcoin::PROTOCOL_VERSION,
+                                                        ba, pos);
+            uint64_t val = bitcoin::ReadCompactSize(vr);
+            return std::make_pair(val, int(vr.GetPos() - pos));
+        } catch (const std::exception &) {
+            return std::nullopt;
+        }
     }
 
     /// Returns the sha256 double hash (not reveresed -- little endian) of the input QByteArray. The results are copied

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -574,23 +574,34 @@ void DownloadBlocksTask::do_get(unsigned int bnum)
                 try {
                     auto rawblock = Util::ParseHexFast(resp.result().toByteArray());
                     const int baseHdr = BTC::GetBlockHeaderSize();        // 80
-                    const int extSz   = BTC::extraHeaderSizeForCoin(ctl->getCoinType());
                     static const QByteArray kVgcExt{"VGC!", 4};
+                    int extra = 0;
                     bool hasExtra = false;
-                    if (ctl->isVGCCoin() && rawblock.size() >= baseHdr + extSz) {
-                        hasExtra = rawblock.mid(baseHdr, extSz) == kVgcExt;
+                    if (ctl->isVGCCoin()) {
+                        if (rawblock.size() >= baseHdr + kVgcExt.size() &&
+                            rawblock.mid(baseHdr, kVgcExt.size()) == kVgcExt) {
+                            int pos = baseHdr + kVgcExt.size();
+                            if (auto opt = BTC::ReadCompactSizeAt(rawblock, pos)) {
+                                auto [len, used] = *opt;
+                                pos += used;
+                                if (rawblock.size() >= pos + int(len)) {
+                                    hasExtra = true;
+                                    extra = (pos - baseHdr) + int(len);
+                                }
+                            }
+                        }
+                    } else {
+                        extra = BTC::extraHeaderSizeForCoin(ctl->getCoinType());
+                        if (extra && rawblock.size() >= baseHdr + extra)
+                            hasExtra = true;
                     }
 
-                    const int headerSize = baseHdr +
-                                            (ctl->isVGCCoin() ? (hasExtra ? extSz : 0)
-                                                             : extSz);
+                    const int headerSize = baseHdr + (hasExtra ? extra : 0);
                     const auto header = rawblock.left(headerSize); // deep copy
                     const auto stdHeader = header.left(baseHdr);
                     QByteArray extraHeader;
-                    if (!ctl->isVGCCoin())
-                        extraHeader = header.mid(baseHdr, extSz);
-                    else if (hasExtra)
-                        extraHeader = header.mid(baseHdr, extSz);
+                    if (hasExtra)
+                        extraHeader = header.mid(baseHdr, extra);
                     QByteArray chkHash;
                     const auto prevBytes = stdHeader.mid(4, 32);
                     QByteArray prevHash(prevBytes);
@@ -601,8 +612,8 @@ void DownloadBlocksTask::do_get(unsigned int bnum)
                         Controller::RpaOnlyModeDataPtr maybe_rpaOnlyMode;  // or this is.. but not both!
                         try {
                             QByteArray trimmed = rawblock;
-                            if (!ctl->isVGCCoin() || hasExtra)
-                                trimmed.remove(baseHdr, extSz);
+                            if (hasExtra)
+                                trimmed.remove(baseHdr, extra);
                             const auto cblock = BTC::Deserialize<bitcoin::CBlock>(trimmed, 0, allowSegWit, allowMimble, allowCashTokens, allowMimble /* throw if junk at end if Litecoin (catch deser. bugs) */);
                             {
                                 VarDLTaskResult var = process_block_guts(bnum, rawblock, cblock, extraHeader);

--- a/src/bitcoin/streams.h
+++ b/src/bitcoin/streams.h
@@ -221,10 +221,8 @@ public:
 
     size_type GetPos() const { return m_pos; }
 
+    /** Set the read position. Throws if the target position is past the end. */
     void seek(size_type new_pos) {
-        if (new_pos < 0) {
-            throw std::ios_base::failure("Cannot seek to a negative offset");
-        }
         if (new_pos > m_data.size()) {
             throw std::ios_base::failure("VectorReader::seek(): end of data");
         }

--- a/src/bitcoin/streams.h
+++ b/src/bitcoin/streams.h
@@ -222,7 +222,12 @@ public:
     size_type GetPos() const { return m_pos; }
 
     void seek(size_type new_pos) {
-        if (new_pos < 0) throw std::ios_base::failure("Cannot seek to a negative offset");
+        if (new_pos < 0) {
+            throw std::ios_base::failure("Cannot seek to a negative offset");
+        }
+        if (new_pos > m_data.size()) {
+            throw std::ios_base::failure("VectorReader::seek(): end of data");
+        }
         m_pos = new_pos;
     }
 };

--- a/src/tests/VGCExtension_tests.cpp
+++ b/src/tests/VGCExtension_tests.cpp
@@ -12,13 +12,24 @@ TEST_SUITE(vgc_extension)
         TEST_CHECK_MESSAGE(f.open(QFile::ReadOnly), "Unable to open resource");
         const QByteArray blockData = f.readAll();
         const int baseHdr = BTC::GetBlockHeaderSize();
-        const int extSz   = BTC::extraHeaderSizeForCoin(BTC::Coin::VGC);
         static const QByteArray kVgcExt{"VGC!",4};
-        bool hasExtra = blockData.size() >= baseHdr + extSz &&
-                         blockData.mid(baseHdr, extSz) == kVgcExt;
+        bool hasExtra = false;
+        int extra = 0;
+        if (blockData.size() >= baseHdr + kVgcExt.size() &&
+            blockData.mid(baseHdr, kVgcExt.size()) == kVgcExt) {
+            int pos = baseHdr + kVgcExt.size();
+            if (auto opt = BTC::ReadCompactSizeAt(blockData, pos)) {
+                auto [len, used] = *opt;
+                pos += used;
+                if (blockData.size() >= pos + int(len)) {
+                    hasExtra = true;
+                    extra = (pos - baseHdr) + int(len);
+                }
+            }
+        }
         TEST_CHECK(!hasExtra);
         auto trimmed = blockData;
-        if (hasExtra) trimmed.remove(baseHdr, extSz);
+        if (hasExtra) trimmed.remove(baseHdr, extra);
         auto blk = BTC::Deserialize<bitcoin::CBlock>(trimmed, 0, false, false, true, false);
         TEST_CHECK(!blk.vtx.empty());
     };


### PR DESCRIPTION
## Summary
- parse VGC's CompactSize header extension if present
- add helper to read CompactSize values from byte arrays
- update controller and tests to handle variable-length VGC extensions

## Testing
- `qmake -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468616f3d48331809e0b97522e8137